### PR TITLE
[FEAT]: Fixes #3. Docker audio not playing on host

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
       - ..:/workspace
+      - /dev:/dev
 
     security_opt:
       - seccomp:unconfined


### PR DESCRIPTION
Steps to test:
1. Re-launch devcontainer for docker-compose to account for new changes.
2. Inside the docker container `cd /workspace/rover/media/audio` and play an audio with `aplay track2.wav`
3. Audio should play as normal. Ensure no other device is using audio in your host system (i.e. Disconnect headphones).